### PR TITLE
Pass log levels along to Stackdriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ configuration as authentication tokens are retrieved from the
   in Stackdriver
 * `journaldriver` can be used outside of GCP by configuring static
   credentials
+* `journaldriver` will recognise journald's log priority levels and
+  convert them into equivalent Stackdriver log severity levels
 
 ## Usage on Google Cloud Platform
 
@@ -60,6 +62,24 @@ performed:
      `journaldriver` if unset, but it is recommended to - for
      example - set it to the machine hostname.
 
+## Log levels / severities / priorities
+
+`journaldriver` recognises [journald's priorities][] and converts them
+into [equivalent severities][] in Stackdriver. Both sets of values
+correspond to standard `syslog` priorities.
+
+The easiest way to emit log messages with priorites from an
+application is to use [priority prefixes][], which are compatible with
+structured log messages.
+
+For example, to emit a simple warning message (structured and
+unstructured):
+
+```
+$ echo '<4>{"fnord":true, "msg":"structured log (warning)"}' | systemd-cat
+$ echo '<4>unstructured log (warning)' | systemd-cat
+```
+
 ## NixOS module
 
 At Aprila we deploy all of our software using [NixOS][], including
@@ -87,13 +107,11 @@ services.journaldriver = {
 **Note**: The `journaldriver`-module is not yet included in a stable
 release of NixOS, but it is available on the `unstable`-channel.
 
-## Upcoming features:
-
-* `journaldriver` will be added to [nixpkgs][] with a complementary
-  [NixOS][] module for easy configuration.
-
 [Stackdriver Logging]: https://cloud.google.com/logging/
 [metadata server]: https://cloud.google.com/compute/docs/storing-retrieving-metadata
 [Google's documentation]: https://cloud.google.com/logging/docs/access-control
 [NixOS]: https://nixos.org/
 [contains a module]: https://github.com/NixOS/nixpkgs/pull/42134
+[journald's priorities]: http://0pointer.de/public/systemd-man/sd-daemon.html
+[equivalent severities]: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity
+[priority prefixes]: http://0pointer.de/public/systemd-man/sd-daemon.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -339,13 +339,30 @@ fn parse_microseconds(input: String) -> Option<DateTime<Utc>> {
     }
 }
 
-/// Converts a journald log message priority (using levels 0/emerg through
-/// 7/debug, see "man journalctl" and "man systemd.journal-fields") to a
-/// Stackdriver-compatible severity number (see
-/// https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity).
-/// Conveniently, the names are the same. Inconveniently, the numbers are not.
+/// Converts a journald log message priority to a
+/// Stackdriver-compatible severity number.
 ///
-/// Any unknown values are returned as an empty option.
+/// Both Stackdriver and journald specify equivalent
+/// severities/priorities. Conveniently, the names are the same.
+/// Inconveniently, the numbers are not.
+///
+/// For more information on the journald priorities, consult these
+/// man-pages:
+///
+/// * systemd.journal-fields(7) (section 'PRIORITY')
+/// * sd-daemon(3)
+/// * systemd.exec(5) (section 'SyslogLevelPrefix')
+///
+/// Note that priorities can be logged by applications via the prefix
+/// concept described in these man pages, without interfering with
+/// structured JSON-payloads.
+///
+/// For more information on the Stackdriver severity levels, please
+/// consult Google's documentation:
+///
+/// https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
+///
+/// Any unknown priority values result in no severity being set.
 fn priority_to_severity(priority: String) -> Option<u32> {
     match priority.as_ref() {
         "0" => Some(800), // emerg

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,7 +8,8 @@ fn test_text_entry_serialization() {
         timestamp: None,
         payload: Payload::TextPayload {
             text_payload: "test entry".into(),
-        }
+        },
+        severity: None,
     };
 
     let expected = "{\"labels\":null,\"textPayload\":\"test entry\"}";
@@ -26,7 +27,8 @@ fn test_json_entry_serialization() {
             json_payload: json!({
                 "message": "JSON test"
             })
-        }
+        },
+        severity: None,
     };
 
     let expected = "{\"labels\":null,\"jsonPayload\":{\"message\":\"JSON test\"}}";


### PR DESCRIPTION
If a priority is present, it is passed as-is into the Stackdriver API.
This allows filtering by severity in the logs UI. Conveniently, the
levels are the same between journald and Stackdriver.

Fixes #11.